### PR TITLE
Docs: Refocus README.md on chawrt compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,16 @@
-![OpenWrt logo](include/logo.png)
+![chawrt logo](include/logo.png)
 
-OpenWrt Project is a Linux operating system targeting embedded devices. Instead
-of trying to create a single, static firmware, OpenWrt provides a fully
-writable filesystem with package management. This frees you from the
-application selection and configuration provided by the vendor and allows you
-to customize the device through the use of packages to suit any application.
-For developers, OpenWrt is the framework to build an application without having
-to build a complete firmware around it; for users this means the ability for
-full customization, to use the device in ways never envisioned.
+chawrt is a variant of the OpenWrt project, focused on providing a custom firmware experience. This guide outlines how to compile chawrt firmware from source.
 
-Sunshine!
+## Building chawrt Firmware
 
-## Download
-
-Built firmware images are available for many architectures and come with a
-package selection to be used as WiFi home router. To quickly find a factory
-image usable to migrate from a vendor stock firmware to OpenWrt, try the
-*Firmware Selector*.
-
-* [OpenWrt Firmware Selector](https://firmware-selector.openwrt.org/)
-
-If your device is supported, please follow the **Info** link to see install
-instructions or consult the support resources listed below.
-
-## 
-
-An advanced user may require additional or specific package. (Toolchain, SDK, ...) For everything else than simple firmware download, try the wiki download page:
-
-* [OpenWrt Wiki Download](https://openwrt.org/downloads)
-
-## Development
-
-To build your own firmware you need a GNU/Linux, BSD or macOS system (case
+To build your own chawrt firmware you need a GNU/Linux, BSD or macOS system (case
 sensitive filesystem required). Cygwin is unsupported because of the lack of a
 case sensitive file system.
 
 ### Requirements
 
-You need the following tools to compile OpenWrt, the package names vary between
+You need the following tools to compile chawrt, the package names vary between
 distributions. A complete list with distribution specific packages is found in
 the [Build System Setup](https://openwrt.org/docs/guide-developer/build-system/install-buildsystem)
 documentation.
@@ -58,51 +31,19 @@ make4.1+ perl python3.7+ rsync subversion unzip which
 3. Run `make menuconfig` to select your preferred configuration for the
    toolchain, target system & firmware packages.
 
-4. Run `make` to build your firmware. This will download all sources, build the
+4. Run `make` to build your chawrt firmware. This will download all sources, build the
    cross-compile toolchain and then cross-compile the GNU/Linux kernel & all chosen
-   applications for your target system.
+   applications for your chawrt target system.
 
 ### Related Repositories
 
-The main repository uses multiple sub-repositories to manage packages of
-different categories. All packages are installed via the OpenWrt package
-manager called `opkg`. If you're looking to develop the web interface or port
-packages to OpenWrt, please find the fitting repository below.
+chawrt uses the following main repositories for its LuCI interface and packages:
 
-* [LuCI Web Interface](https://github.com/openwrt/luci): Modern and modular
+* [LuCI Web Interface](https://github.com/liudf0716/luci): Modern and modular
   interface to control the device via a web browser.
 
-* [OpenWrt Packages](https://github.com/openwrt/packages): Community repository
-  of ported packages.
-
-* [OpenWrt Routing](https://github.com/openwrt/routing): Packages specifically
-  focused on (mesh) routing.
-
-* [OpenWrt Video](https://github.com/openwrt/video): Packages specifically
-  focused on display servers and clients (Xorg and Wayland).
-
-## Support Information
-
-For a list of supported devices see the [OpenWrt Hardware Database](https://openwrt.org/supported_devices)
-
-### Documentation
-
-* [Quick Start Guide](https://openwrt.org/docs/guide-quick-start/start)
-* [User Guide](https://openwrt.org/docs/guide-user/start)
-* [Developer Documentation](https://openwrt.org/docs/guide-developer/start)
-* [Technical Reference](https://openwrt.org/docs/techref/start)
-
-### Support Community
-
-* [Forum](https://forum.openwrt.org): For usage, projects, discussions and hardware advise.
-* [Support Chat](https://webchat.oftc.net/#openwrt): Channel `#openwrt` on **oftc.net**.
-
-### Developer Community
-
-* [Bug Reports](https://bugs.openwrt.org): Report bugs in OpenWrt
-* [Dev Mailing List](https://lists.openwrt.org/mailman/listinfo/openwrt-devel): Send patches
-* [Dev Chat](https://webchat.oftc.net/#openwrt-devel): Channel `#openwrt-devel` on **oftc.net**.
+* [chawrt Packages](https://github.com/liudf0716/packages): Main package repository for chawrt.
 
 ## License
 
-OpenWrt is licensed under GPL-2.0
+chawrt is licensed under GPL-2.0


### PR DESCRIPTION
The README.md has been significantly revised to focus solely on providing instructions for compiling chawrt firmware.

Changes include:
- Removed general OpenWrt project description, download links, and support/community information.
- Updated title and introduction to be chawrt-specific.
- Ensured development quickstart instructions refer to chawrt.
- Updated LuCI and Packages repository links to the specified chawrt project URLs (liudf0716/luci and liudf0716/packages).
- Removed links to other OpenWrt package categories.
- Updated license to refer to chawrt.

The resulting README is now a concise guide for building chawrt.

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
